### PR TITLE
Make matching flow step more observable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.flocktory/wf "0.1.0"
+(defproject com.flocktory/wf "0.2.0"
   :description "Reactive workflow engine scaffold"
   :url "https://github.com/flocktory/wf"
   :license {:name "Eclipse Public License"

--- a/src/wf/impl.clj
+++ b/src/wf/impl.clj
@@ -290,10 +290,12 @@
         matches (set (flows-matching-by-Entry-nodes engine flows event))]
     (when (seq matches)
       (callback! engine :wf.callback/matched-flows {:wf/event event
+                                                    :wf/active-flows active-flows
                                                     :wf/matching-flows matches}))
     (loop [matches* matches]
       (if (empty? matches*)
-        (callback! engine :wf.callback/event-unmatched {:wf/event event})
+        (callback! engine :wf.callback/event-unmatched {:wf/event event
+                                                        :wf/active-flows active-flows})
         (let [context-id (generate-context-id)
               [matching-flow init-node-id :as match]
               (elect-flow engine matches* event context-id)
@@ -310,7 +312,8 @@
             (= ::reelect result)
             (recur (disj matches* match))
             (= ::unmatched result)
-            (callback! engine :wf.callback/event-unmatched {:wf/event event})))))))
+            (callback! engine :wf.callback/event-unmatched {:wf/event event
+                                                            :wf/active-flows active-flows})))))))
 
 (defn- get-interrupted-contexts-with-flows
   [engine context-key]

--- a/src/wf/impl.clj
+++ b/src/wf/impl.clj
@@ -290,12 +290,12 @@
         matches (set (flows-matching-by-Entry-nodes engine flows event))]
     (when (seq matches)
       (callback! engine :wf.callback/matched-flows {:wf/event event
-                                                    :wf/active-flows active-flows
+                                                    :wf/active-flows flows
                                                     :wf/matching-flows matches}))
     (loop [matches* matches]
       (if (empty? matches*)
         (callback! engine :wf.callback/event-unmatched {:wf/event event
-                                                        :wf/active-flows active-flows})
+                                                        :wf/active-flows flows})
         (let [context-id (generate-context-id)
               [matching-flow init-node-id :as match]
               (elect-flow engine matches* event context-id)
@@ -313,7 +313,7 @@
             (recur (disj matches* match))
             (= ::unmatched result)
             (callback! engine :wf.callback/event-unmatched {:wf/event event
-                                                            :wf/active-flows active-flows})))))))
+                                                            :wf/active-flows flows})))))))
 
 (defn- get-interrupted-contexts-with-flows
   [engine context-key]


### PR DESCRIPTION
This update add additinal argument with all active flows (:wf/active-flows) to calbacks (:wf.callback/matched-flows, :wf.callback/event-unmatched) data